### PR TITLE
Remove SonicWall_Wall selection box

### DIFF
--- a/Factorio-Tiberium/scripts/TiberiumControlNetwork.lua
+++ b/Factorio-Tiberium/scripts/TiberiumControlNetwork.lua
@@ -572,7 +572,6 @@ data:extend{
         subgroup = "remnants",
         order = "a[remnants]",
         max_health = 10000,
-        selection_box = {{-0.5, -0.5}, {0.5, 0.5}},
         collision_box = {{-0.4, -0.4}, {0.4, 0.4}},
 		collision_mask = {"layer-15"},
         pictures = {


### PR DESCRIPTION
The selection box prevents any entities underneath the wall from being selected (e.g., belts), preventing manual deconstruction.