### PR TITLE
Fixes a crash if wall[2] becomes invalid

### DIFF
--- a/Factorio-Tiberium/scripts/CnC_Walls.lua
+++ b/Factorio-Tiberium/scripts/CnC_Walls.lua
@@ -136,13 +136,22 @@ function CnC_SonicWall_WallDamage(surf, pos, tick)
 	if global.SRF_segments[surf.index] and global.SRF_segments[surf.index][x] and global.SRF_segments[surf.index][x][y] then
 		local mark_death = false
 		local force = nil
-		
+
 		local wall = global.SRF_segments[surf.index][x][y]
+		local connected_nodes = CnC_SonicWall_FindNodes(surf, pos, nil, wall[1], true) --What did the extra arg originally do?
+
+		if not wall[2].valid then
+			local node = connected_nodes[1]
+			CnC_SonicWall_SendAlert(node.force, defines.alert_type.entity_destroyed, node)
+			CnC_SonicWall_DisableNode(node)
+			table.insert(global.SRF_node_ticklist, {emitter = node, position = node.position, tick = tick + ceil(node.electric_buffer_size / node.electric_input_flow_limit)})
+			return
+		end
+		
 		local damage_amt = wall_health - wall[2].health
 		wall[2].health = wall_health
 		local joule_cost = damage_amt * joules_per_hitpoint
 		
-		local connected_nodes = CnC_SonicWall_FindNodes(surf, pos, nil, wall[1], true) --What did the extra arg originally do?
 		local shared_cost = joule_cost / #connected_nodes
 		for _, node in pairs(connected_nodes) do
 			if not force then force = node.force end


### PR DESCRIPTION
Hello everyone,

I already reported this bug in Discord (the second report in `ticket-0122`),
but now the crash would happen deterministically, so I needed to fix it myself 😉.


## Stack trace of error

```lua
Error MainLoop.cpp:1207: Exception at tick 41672978: The mod Factorio and Conquer: Tiberian Dawn (1.0.9) caused a non-recoverable error.
Please report this error to the mod author.
Error while running event Factorio-Tiberium::on_tick (ID 0)
LuaEntity API call when LuaEntity was invalid.
stack traceback:
  __Factorio-Tiberium__/scripts/CnC_Walls.lua:141: in function 'CnC_SonicWall_WallDamage'
  __Factorio-Tiberium__/scripts/CnC_Walls.lua:260: in function 'CnC_SonicWall_OnTick'
  __Factorio-Tiberium__/control.lua:679: in function <__Factorio-Tiberium__/control.lua:677>
stack traceback:
  [C]: in function '__index'
  __Factorio-Tiberium__/scripts/CnC_Walls.lua:141: in function 'CnC_SonicWall_WallDamage'
  __Factorio-Tiberium__/scripts/CnC_Walls.lua:260: in function 'CnC_SonicWall_OnTick'
  __Factorio-Tiberium__/control.lua:679: in function <__Factorio-Tiberium__/control.lua:677>
```

## Description of the fix

Factorio crashed while trying to access the health property of wall[2].
This commit checks the validity of the LuaEntity and adds the affected
node to the SRF_node_ticklist, so that the SRF wall will be rebuilded.

P.S.:
It would be nice if you could release this fix as version `1.0.10`, as I'm currently using this fix together
with this specific version on my server.

Cheers,
Nicolas and René