### PR TITLE
fixes k2 compatibility

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -43,3 +43,4 @@ end
 
 require("scripts.DynamicOreRecipes")
 require("scripts.compatibility.pumpmod")
+require("scripts.compatibility.Krastorio2-final-fixes")

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -277,7 +277,7 @@ if settings.startup["tiberium-advanced-start"].value or common.whichPlanet == "t
 end
 
 -- Remove non-Tiberium ores from Tberium-only Nauvis
-if common.whichPlanet == "pure-nauvis" then
+if common.whichPlanet == "pure-nauvis" and not mods["Krastorio2"] then
 	if data.raw.planet.nauvis and data.raw.planet.nauvis.map_gen_settings and data.raw.planet.nauvis.map_gen_settings.autoplace_settings and
 			data.raw.planet.nauvis.map_gen_settings.autoplace_settings.entity and data.raw.planet.nauvis.map_gen_settings.autoplace_settings.entity.settings then
 		data.raw.planet.nauvis.map_gen_settings.autoplace_settings.entity.settings["tiberium-tiber-rock"] = {}

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -277,7 +277,7 @@ if settings.startup["tiberium-advanced-start"].value or common.whichPlanet == "t
 end
 
 -- Remove non-Tiberium ores from Tberium-only Nauvis
-if common.whichPlanet == "pure-nauvis" and not mods["Krastorio2"] then
+if common.whichPlanet == "pure-nauvis" then
 	if data.raw.planet.nauvis and data.raw.planet.nauvis.map_gen_settings and data.raw.planet.nauvis.map_gen_settings.autoplace_settings and
 			data.raw.planet.nauvis.map_gen_settings.autoplace_settings.entity and data.raw.planet.nauvis.map_gen_settings.autoplace_settings.entity.settings then
 		data.raw.planet.nauvis.map_gen_settings.autoplace_settings.entity.settings["tiberium-tiber-rock"] = {}

--- a/prototype/recipe.lua
+++ b/prototype/recipe.lua
@@ -475,7 +475,7 @@ data:extend{
 				icon_size = 64,
 			},
 			{
-				icon = tiberiumInternalName .. "graphics/icons/fluid/tiberium-sludge.png",
+				icon = tiberiumInternalName .. "/graphics/icons/fluid/tiberium-sludge.png",
 				icon_size = 64,
 				scale = 0.25,
 				shift = { 6, -6 }

--- a/scripts/compatibility/Krastorio2-final-fixes.lua
+++ b/scripts/compatibility/Krastorio2-final-fixes.lua
@@ -1,0 +1,17 @@
+if not mods["Krastorio2"] then
+    return
+end
+--hide my crimes from the player
+--krastorio2 generates some protype stuff for crushing and the "Welcome to the jungle" tech
+if mods["Krastorio2"] then
+    if settings.startup["tiberium-on"].value == "nauvis" then
+        for prototypes in pairs(data.raw) do
+            for _, name in ipairs({"tiberium-tiber-rock", "kr-crush-tiberium-tiber-rock"}) do
+                if prototypes[name] then
+                    prototypes[name].hidden_in_factoriopedia = true
+                    prototypes[name].hidden = true
+                end
+            end
+        end
+    end
+end

--- a/scripts/compatibility/Krastorio2.lua
+++ b/scripts/compatibility/Krastorio2.lua
@@ -78,9 +78,7 @@ if mods["Krastorio2"] then
 			local dummy_item = table.deepcopy(data.raw["item"]["simple-entity-with-force"])
 			local dummy_resource = table.deepcopy(data.raw["resource"]["stone"])
 			dummy_item.name = "tiberium-tiber-rock"
-			dummy_item.hidden_in_factoriopedia = true
 			dummy_resource.name = "tiberium-tiber-rock"
-			dummy_resource.hidden_in_factoriopedia = true
 			data:extend({dummy_item, dummy_resource})
 		end
 	end

--- a/scripts/compatibility/Krastorio2.lua
+++ b/scripts/compatibility/Krastorio2.lua
@@ -71,10 +71,8 @@ if mods["Krastorio2"] then
 		end
 	end
 
-	-- Make Tiberium Magazines usable with rifles again
-	-- if krastorio.general.getSafeSettingValue("kr-more-realistic-weapon") then
-	-- 	common.recipe.editIngredient("tiberium-rounds-magazine", "piercing-rounds-magazine", "rifle-magazine")
-	-- end
+	--make a dummy item cause i cannot understand how tiberium-tiber-rock is being made and if you dont do this the game hangs with a missing entityID
+	--for tiberium-tiber-rock, this is so god awful stuff but it works so?????
 	if mods["Krastorio2"] then
 		if settings.startup["tiberium-on"].value == "nauvis" then
 			local dummy_item = table.deepcopy(data.raw["item"]["simple-entity-with-force"])
@@ -86,6 +84,10 @@ if mods["Krastorio2"] then
 			data:extend({dummy_item, dummy_resource})
 		end
 	end
+	-- Make Tiberium Magazines usable with rifles again
+	-- if krastorio.general.getSafeSettingValue("kr-more-realistic-weapon") then
+	-- 	common.recipe.editIngredient("tiberium-rounds-magazine", "piercing-rounds-magazine", "rifle-magazine")
+	-- end
 	if settings.startup ["kr-more-realistic-weapon"] then
 			common.recipe.editIngredient("tiberium-rounds-magazine", "piercing-rounds-magazine", "kr-rifle-magazine")
 	end

--- a/scripts/compatibility/Krastorio2.lua
+++ b/scripts/compatibility/Krastorio2.lua
@@ -47,21 +47,23 @@ if mods["Krastorio2"] then
 		}
 	for technology_name, technology in pairs(data.raw.technology) do
 		if string.sub(technology_name, 1, 9) == "tiberium-" then
+			if technology.unit and technology.unit.ingredients then
 			technology.check_science_packs_incompatibilities = false
 			-- Do a version of pack incompatibilities
 			local ingredients = technology.unit.ingredients
-			if ingredients and #ingredients > 1 then
-				local has_space = false
-				for i = 1, #ingredients do
-					if ingredients[i][1] == "space-science-pack" then
-						has_space = true
-						break
+				if ingredients and #ingredients > 1 then
+					local has_space = false
+					for i = 1, #ingredients do
+						if ingredients[i][1] == "space-science-pack" then
+							has_space = true
+							break
+						end
 					end
-				end
-				if has_space then
-					for i = #ingredients, 1, -1 do
-						if science_pack_incompatibilities[ingredients[i][1]] then
-							table.remove(ingredients, i)
+					if has_space then
+						for i = #ingredients, 1, -1 do
+							if science_pack_incompatibilities[ingredients[i][1]] then
+								table.remove(ingredients, i)
+							end
 						end
 					end
 				end
@@ -70,8 +72,22 @@ if mods["Krastorio2"] then
 	end
 
 	-- Make Tiberium Magazines usable with rifles again
-	if krastorio.general.getSafeSettingValue("kr-more-realistic-weapon") then
-		common.recipe.editIngredient("tiberium-rounds-magazine", "piercing-rounds-magazine", "rifle-magazine")
+	-- if krastorio.general.getSafeSettingValue("kr-more-realistic-weapon") then
+	-- 	common.recipe.editIngredient("tiberium-rounds-magazine", "piercing-rounds-magazine", "rifle-magazine")
+	-- end
+	if mods["Krastorio2"] then
+		if settings.startup["tiberium-on"].value == "nauvis" then
+			local dummy_item = table.deepcopy(data.raw["item"]["simple-entity-with-force"])
+			local dummy_resource = table.deepcopy(data.raw["resource"]["stone"])
+			dummy_item.name = "tiberium-tiber-rock"
+			dummy_item.hidden_in_factoriopedia = true
+			dummy_resource.name = "tiberium-tiber-rock"
+			dummy_resource.hidden_in_factoriopedia = true
+			data:extend({dummy_item, dummy_resource})
+		end
+	end
+	if settings.startup ["kr-more-realistic-weapon"] then
+			common.recipe.editIngredient("tiberium-rounds-magazine", "piercing-rounds-magazine", "kr-rifle-magazine")
 	end
 	local oldTibRounds = data.raw.ammo["tiberium-rounds-magazine"]
 	local newTibRounds = util.copy(data.raw.ammo["uranium-rifle-magazine"])


### PR DESCRIPTION
this is pretty cursed, another way to fix it would be reverse k2 and tiberium dawns dependency so that tiberium dawn loads before krastorio2, that would require raiguard to change the k2 json and also would probably need to move some of the krastroio2 compat code in this mod to final-fixes.

but this works, the mod loads, the techs all work, the settings work, i have not testing this with space age.