### PR TITLE
Canal Excavator Compatibility

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -88,3 +88,5 @@ if mods["any-planet-start"] and APS and (common.whichPlanet == "tiber" or common
 	APS.add_planet{name = "tiber", filename = tiberiumInternalName.."/prototype/planet.lua", technology = "planet-discovery-tiber"}
 	if common.whichPlanet == "tiber-start" then settings.startup["aps-planet"].value = "tiber" end
 end
+
+if mods["canal-excavator"] then require("prototype/compatibility/canal-excavator") end

--- a/info.json
+++ b/info.json
@@ -39,6 +39,7 @@
 		"? RampantResources >= 1.2.0",
 		"? rso-mod >= 7.0.15",
 		"? space-exploration",
-		"? space-exploration-postprocess >= 0.6.18"
+		"? space-exploration-postprocess >= 0.6.18",
+		"? canal-excavator >= 1.12"
 	]
 }

--- a/prototype/compatibility/canal-excavator.lua
+++ b/prototype/compatibility/canal-excavator.lua
@@ -1,0 +1,21 @@
+if not mods["canal-excavator"] then return end
+
+data:extend({{
+  type = "mod-data",
+  name = "canex-tiber-config",
+  data_type = "canex-surface-config",
+  data = {
+    surfaceName = "tiber",
+    localisation = {"space-location-name.tiber"},
+    oreStartingAmount = 5,
+    mining_time = 8,
+    tint = {r = 82, g = 108, b = 6},
+    mineResult = {
+      {type="item", name = "stone", probability = 0.98, amount = 1},
+      {type="item", name = "tiberium-ore", probability = 0.02, amount = 1},
+    },
+    icon_data = {
+      icon_size = 512,
+    }
+  }
+}})


### PR DESCRIPTION
Hi,

Some users of my [Canal Excavator](https://mods.factorio.com/mod/canal-excavator) mod asked me to implement compatibility with more planet mods.
Personally I think it's cleaner if the compatibility code is in the planet mod so they planet devs can give their input in the balance.

I've configured the excavatable resource on Tiber to yield a small amount of stone and trace amounts of Tiberium ore for flavor. Since Tiber doesn't have native stone and since the tiles required to excavate cost 5 stone each, the total stone yielded is net negative as to not upset the balance of Tiber.

And since the total amount of resources is so low, I've compensated by setting the mining time to be fairly high as to not make it trivial to excavate the ground.

Let me know what you think.